### PR TITLE
Handle duplicative dll paths

### DIFF
--- a/MiniAVC/AddonLibrary.cs
+++ b/MiniAVC/AddonLibrary.cs
@@ -89,12 +89,31 @@ namespace MiniAVC
             {
                 var threadAddons = new List<Addon>();
                 var threadSettings = new List<AddonSettings>();
+                var versionFileSettings = new Dictionary<string, AddonSettings>();
                 foreach (var rootPath in AssemblyLoader.loadedAssemblies.Where(a => a.name == "MiniAVC").Select(a => Path.GetDirectoryName(a.path)))
                 {
                     var settings = AddonSettings.Load(rootPath);
                     threadSettings.Add(settings);
-                    threadAddons.AddRange(Directory.GetFiles(rootPath, "*.version", SearchOption.AllDirectories).Select(p => new Addon(p, settings)).ToList());
+                    foreach (string versionFile in Directory.GetFiles(rootPath, "*.version", SearchOption.AllDirectories)
+                    {
+                        // Check whether we've already seen this file
+                        AddonSettings prevSettings;
+                        if (versionFileSettings.TryGetValue(versionFile, out prevSettings))
+                        {
+                            // Use the settings closest to the DLL (== longest path)
+                            if (prevSettings.FileName.Length < settings.FileName.Length)
+                            {
+                                versionFileSettings[versionFile] = settings;
+                            }
+                        }
+                        else
+                        {
+                            versionFileSettings.Add(versionFile, settings);
+                        }
+                    }
                 }
+                threadAddons.AddRange(versionFileSettings.Select(kvp => new Addon(kvp.Key, kvp.Value)));
+
                 addons = threadAddons;
                 Settings = threadSettings;
                 Populated = true;


### PR DESCRIPTION
## Motivation

https://github.com/KSP-CKAN/NetKAN/issues/1455#issuecomment-217134778

> If a copy of miniavc.dll exists in both the GameData base folder and any subfolder then all dialogs surfaced by the mod are surfaced twice and that is annoying AF if you have a couple hundred mods installed.

This pull request aims to fix that.

## Cause

The scenario described above can be generalized to any situation in which two copies of MiniAVC.dll are located in directories which are in an ancestor/descendant relationship. E.g.:

- GameData/MiniAVC.dll
- GameData/Astrogator/MiniAVC.dll

Or even something like:

- GameData/HeavilyBundledMod/MiniAVC.dll
- GameData/HeavilyBundledMod/AnotherMod/Plugins/MiniAVC.dll

In those cases, this code will find version files in the nested subfolder multiple times and add them to the list of addons to check:

https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/0caed8a8baffbd78885d1f8a701a803b2ba20463/MiniAVC/AddonLibrary.cs#L90-L100

Later this results in multiple popups if there are incompatibilities or updates.

## Changes

Now we build a temporary `Dictionary` that tracks version files and their associated settings. If we find the same version file more than once, we don't add it multiple times; instead we compare the associated settings files and choose the one that is closest to that version file. Once we've checked all the files, we collapse the `Dictionary` to a list of `Addons`, as before.

This is what I was trying to compile on the mod adoption tutorial thread. I have not been able to get the build working, so there may be syntax errors here; just let me know and I'll fix them.