### PR TITLE
Override GUI adjustments

### DIFF
--- a/KSP-AVC/CompatibilityOverrideAdvSettingsGui.cs
+++ b/KSP-AVC/CompatibilityOverrideAdvSettingsGui.cs
@@ -14,6 +14,7 @@ namespace KSP_AVC
         private GUIStyle boxStyle;
         private GUIStyle buttonStyle;
         private GUIStyle labelStyle;
+        private GUIStyle labelStyleWhite;
         private GUIStyle labelStyleYellow;
         private GUIStyle labelStyleCyan;
         private GUIStyle toggleStyle;
@@ -108,14 +109,40 @@ namespace KSP_AVC
             GUILayout.BeginHorizontal();
             DrawIgnoreOverrideSettings();
             GUILayout.EndHorizontal();
+            GUILayout.BeginHorizontal();
+            DrawDefaultValueSettings();
+            GUILayout.EndHorizontal();
             GUILayout.EndVertical();
+        }
+
+        private void DrawDefaultValueSettings()
+        {
+            bool toggleState = Configuration.ShowDefaultValues;
+            GUILayout.BeginVertical();
+            DrawHeadingsDefaultValue();
+            GUILayout.BeginHorizontal(this.scrollList);
+            GUILayout.Label("Show preset values in addon list", this.labelStyleWhite);
+            GUILayout.FlexibleSpace();
+            toggleState = GUILayout.Toggle(toggleState, "", this.toggleStyle);
+            if(toggleState != Configuration.ShowDefaultValues)
+            {
+                Configuration.ShowDefaultValues = !Configuration.ShowDefaultValues;
+            }
+            GUILayout.Space(25);
+            GUILayout.EndHorizontal();
+            GUILayout.EndVertical();
+        }
+
+        private void DrawHeadingsDefaultValue()
+        {
+            GUILayout.Label("OTHER SETTINGS", this.topLevelTitleStyle);
         }
 
         private void DrawAdvancedInfo()
         {
             GUILayout.BeginHorizontal();
             GUILayout.Label("This is the ignore list for the compatibile version override." +
-                "\nAny mod on the ignore list will no longer be affected by the version range." +
+                "\nAny mod on the ignore list will no longer be affected by the version range. " +
                 "It is still possible to put an ignored mod, on the \"ALWAYS OVERRIDE\" list.", this.labelStyle);
             GUILayout.EndHorizontal();
         }
@@ -187,6 +214,16 @@ namespace KSP_AVC
             this.labelStyle = new GUIStyle(HighLogic.Skin.label)
             {
                 alignment = TextAnchor.MiddleLeft
+            };
+
+            this.labelStyleWhite = new GUIStyle(HighLogic.Skin.label)
+            {
+                normal =
+                {
+                    textColor = Color.white
+                },
+                alignment = TextAnchor.MiddleLeft,
+                fontStyle = FontStyle.Bold,
             };
 
             this.labelStyleYellow = new GUIStyle(HighLogic.Skin.label)

--- a/KSP-AVC/CompatibilityOverrideGui.cs
+++ b/KSP-AVC/CompatibilityOverrideGui.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
 using UnityEngine;
-using System.Text.RegularExpressions;
 
 namespace KSP_AVC
 {
@@ -25,6 +24,7 @@ namespace KSP_AVC
         private GUIStyle labelStyleYellow;
         private GUIStyle labelStyleCyan;
         private GUIStyle buttonStyleGreen;
+        private GUIStyle labelStyleIgnore;
         private Vector2 scrollPositionVersionInfo = Vector2.zero;
         private Vector2 scrollPositionAddonList = Vector2.zero;
         private Vector2 scrollPositionNameList = Vector2.zero;
@@ -59,7 +59,7 @@ namespace KSP_AVC
                 for (int i = 3; i <= Versioning.version_minor; i++)
                     versions.Add("1." + i.ToString() + ".*");
 
-                InitEnabledCompatVersions();
+                //InitEnabledCompatVersions();
             }
             catch (Exception ex)
             {
@@ -146,10 +146,9 @@ namespace KSP_AVC
         {
             GUILayout.BeginVertical();
             DrawHeadingsOverrideVersion();
-            scrollPositionVersionInfo = GUILayout.BeginScrollView(scrollPositionVersionInfo, this.scrollList, GUILayout.Width(230), GUILayout.Height(275));
-          
+            scrollPositionVersionInfo = GUILayout.BeginScrollView(scrollPositionVersionInfo, this.scrollList, GUILayout.Width(230), GUILayout.Height(275));          
             DrawVersionList();
-            DrawStdCompatToggles();
+            //DrawStdCompatToggles();
             GUILayout.EndScrollView();
             DrawInputOverrideVersion();
             GUILayout.EndVertical();
@@ -159,7 +158,7 @@ namespace KSP_AVC
         private void DrawHeadingsOverrideVersion()
         {
             GUILayout.BeginHorizontal();
-            GUILayout.Label("COMPAT. VERSION OVERRIDE", this.topLevelTitleStyle, GUILayout.MinWidth(200));
+            GUILayout.Label("COMPATIBLE VERSION OVERRIDE", this.topLevelTitleStyle, GUILayout.MinWidth(230));
             GUILayout.EndHorizontal();
         }
 
@@ -183,16 +182,16 @@ namespace KSP_AVC
                     if (GUILayout.Button("X", this.buttonStyleRed, GUILayout.Width(25), GUILayout.Height(25)))
                     {
                         GuiHelper.UpdateCompatibilityState(OverrideType.version, null, Configuration.CompatibleVersions[key].currentVersion + "," + Configuration.CompatibleVersions[key].compatibleWithVersion[i], true);
-                        if (Configuration.CompatibleVersions[key].compatibleWithVersion[i] == AddonInfo.ActualKspVersion.ToString() )
-                        {
-                            for (int i1 = 0; i1 < versions.Count(); i1++)
-                            {
-                                if (versions[i1] == Configuration.CompatibleVersions[key].currentVersion.Replace("-1", "*"))
-                                {
-                                    enabledCompatVersions[i1] = false;
-                                }
-                            }
-                        }
+                        //if (Configuration.CompatibleVersions[key].compatibleWithVersion[i] == AddonInfo.ActualKspVersion.ToString() )
+                        //{
+                        //    for (int i1 = 0; i1 < versions.Count(); i1++)
+                        //    {
+                        //        if (versions[i1] == Configuration.CompatibleVersions[key].currentVersion.Replace("-1", "*"))
+                        //        {
+                        //            enabledCompatVersions[i1] = false;
+                        //        }
+                        //    }
+                        //}
                     }
                     GUILayout.EndHorizontal();
                 }
@@ -200,62 +199,62 @@ namespace KSP_AVC
             Configuration.DeleteFinally();
         }
 
-        void InitEnabledCompatVersions()
-        {
-            for (int i = 0; i < versions.Count(); i++)
-            {
-                string v = versions[i].Replace("*", "-1");
-                CompatVersions cv;
-                if (Configuration.CompatibleVersions.TryGetValue(v, out cv))
-                {
-                    VersionInfo vi = new VersionInfo(Versioning.version_major, Versioning.version_minor, Versioning.Revision, 0);
+        //void InitEnabledCompatVersions()
+        //{
+        //    for (int i = 0; i < versions.Count(); i++)
+        //    {
+        //        string v = versions[i].Replace("*", "-1");
+        //        CompatVersions cv;
+        //        if (Configuration.CompatibleVersions.TryGetValue(v, out cv))
+        //        {
+        //            VersionInfo vi = new VersionInfo(Versioning.version_major, Versioning.version_minor, Versioning.Revision, 0);
 
-                    if (cv.compatWithVersion.Contains(vi))
-                    {
-                        enabledCompatVersions[i] = true;
-                    }
-                }                
-            }
-        }
-        void CheckCompatVersion(string version)
-        {
-            Debug.Log("CheckCompatVersion, version: " + version);
-            for (int i = 0; i < versions.Count(); i++)
-            {
-                Debug.Log("versions[" + i + "]: " + versions[i]);
-                if (version == versions[i])
-                    enabledCompatVersions[i] = true;
-            }
-        }
-        //Input textfield and "ADD" button
+        //            if (cv.compatWithVersion.Contains(vi))
+        //            {
+        //                enabledCompatVersions[i] = true;
+        //            }
+        //        }                
+        //    }
+        //}
+
+        //void CheckCompatVersion(string version)
+        //{
+        //    Debug.Log("CheckCompatVersion, version: " + version);
+        //    for (int i = 0; i < versions.Count(); i++)
+        //    {
+        //        Debug.Log("versions[" + i + "]: " + versions[i]);
+        //        if (version == versions[i])
+        //            enabledCompatVersions[i] = true;
+        //    }
+        //}
         
-        void DrawStdCompatToggles()
-        {
-            if (Configuration.OverrideIsDisabledGlobal)
-                return;
-            for (int i = 0; i < versions.Count(); i++)
-            {
-                Debug.Log("DrawStdCompatToggles, i:" + i);
-                GUILayout.BeginHorizontal();
-                bool b = GUILayout.Toggle(enabledCompatVersions[i], versions[i]);
-                if (b != enabledCompatVersions[i])
-                {
-                    string v = versions[i].Replace("*", "-1");
-                    enabledCompatVersions[i] = b;
-                    if (enabledCompatVersions[i])
-                    {
-                        GuiHelper.UpdateCompatibilityState(OverrideType.version, null, v);
-                        Logger.Log($"AVC Compatibility Override, Version input: " + v);
-                    }
-                    else
-                    {                       
-                        GuiHelper.UpdateCompatibilityState(OverrideType.version , null, v + "," + AddonInfo.ActualKspVersion.ToString(), true);
-                        Logger.Log($"AVC Compatibility Override remove , Version input: " + v);
-                    }
-                }
-                GUILayout.EndHorizontal();
-            }
-        }
+        //void DrawStdCompatToggles()
+        //{
+        //    if (Configuration.OverrideIsDisabledGlobal)
+        //        return;
+        //    for (int i = 0; i < versions.Count(); i++)
+        //    {
+        //        Debug.Log("DrawStdCompatToggles, i:" + i);
+        //        GUILayout.BeginHorizontal();
+        //        bool b = GUILayout.Toggle(enabledCompatVersions[i], versions[i]);
+        //        if (b != enabledCompatVersions[i])
+        //        {
+        //            string v = versions[i].Replace("*", "-1");
+        //            enabledCompatVersions[i] = b;
+        //            if (enabledCompatVersions[i])
+        //            {
+        //                GuiHelper.UpdateCompatibilityState(OverrideType.version, null, v);
+        //                Logger.Log($"AVC Compatibility Override, Version input: " + v);
+        //            }
+        //            else
+        //            {                       
+        //                GuiHelper.UpdateCompatibilityState(OverrideType.version , null, v + "," + AddonInfo.ActualKspVersion.ToString(), true);
+        //                Logger.Log($"AVC Compatibility Override remove , Version input: " + v);
+        //            }
+        //        }
+        //        GUILayout.EndHorizontal();
+        //    }
+        //}
 
         private void DrawInputOverrideVersion()
         {
@@ -264,9 +263,8 @@ namespace KSP_AVC
             if (GUILayout.Button("ADD", this.buttonStyle, GUILayout.Width(75), GUILayout.Height(20)))
             {
                 Debug.Log("userInput: " + GuiHelper.userInput);
-                CheckCompatVersion(GuiHelper.userInput);
-                GuiHelper.UpdateCompatibilityState(OverrideType.version, null, GuiHelper.userInput);
-               
+                //CheckCompatVersion(GuiHelper.userInput);
+                GuiHelper.UpdateCompatibilityState(OverrideType.version, null, GuiHelper.userInput);               
 
                 Logger.Log($"AVC Compatibility Override, Version input: {GuiHelper.userInput}");
             }
@@ -311,10 +309,14 @@ namespace KSP_AVC
                 DrawNoIncompatibleAddons();
                 return;
             }
+            if (Configuration.ShowDefaultValues)
+            {
+                DrawDefaultValues(); 
+            }
             for (int i = 0; i < m; i++)
             {
                 Addon addon = listIncompatibleMods[i];
-                GUIStyle coloredLabel = (GuiHelper.CompatibilityState(OverrideType.version, addon) || GuiHelper.CompatibilityState(OverrideType.name, addon)) ? this.labelStyleCyan : this.labelStyleYellow;
+                GUIStyle coloredLabel = (GuiHelper.CompatibilityState(OverrideType.version, addon) || GuiHelper.CompatibilityState(OverrideType.name, addon)) ? this.labelStyleCyan : GuiHelper.CompatibilityState(OverrideType.ignore, addon) ? this.labelStyleIgnore : this.labelStyleYellow; //highlighting ignored mods
                 VersionInfo versionNumber = addon.LocalInfo.KspVersionMaxIsNull && addon.LocalInfo.KspVersionMinIsNull ? addon.LocalInfo.KspVersion : addon.LocalInfo.KspVersionMax;
 
                 GUILayout.BeginHorizontal();
@@ -325,6 +327,23 @@ namespace KSP_AVC
                 GUILayout.Label($"{versionNumber}", coloredLabel, GUILayout.MinWidth(65));
                 GUILayout.Space(18);
                 DrawButtonArrowRight(addon);
+                GUILayout.FlexibleSpace();
+                GUILayout.EndHorizontal();
+            }
+        }
+
+        private void DrawDefaultValues()
+        {
+            for (int i = 0; i < versions.Count(); i++)
+            {
+                GUIStyle coloredLabel = GuiHelper.CompatibilityState(OverrideType.version, null, versions[i]) ? this.labelStyleCyan : this.labelStyleYellow;
+                GUILayout.BeginHorizontal();
+                GUILayout.Space(51);
+                GUILayout.Label("(PRESET) Enable Override for:", coloredLabel, GUILayout.MinWidth(230.0f));
+                GUILayout.Space(10);
+                GUILayout.Label(versions[i], coloredLabel, GUILayout.MinWidth(65));
+                GUILayout.Space(18);
+                DrawButtonArrowRight(versions[i]);
                 GUILayout.FlexibleSpace();
                 GUILayout.EndHorizontal();
             }
@@ -344,7 +363,20 @@ namespace KSP_AVC
             {
                 if (!GuiHelper.CompatibilityState(OverrideType.version, addon))
                 {
-                    GuiHelper.UpdateCompatibilityState(OverrideType.version, null, addon.LocalInfo.KspVersionMaxIsNull && addon.LocalInfo.KspVersionMinIsNull ? addon.LocalInfo.KspVersion.ToString() : addon.LocalInfo.KspVersionMax.ToString()); //addon.LocalInfo.KspVersionMax == AddonInfo.ActualKspVersion ? addon.LocalInfo.KspVersion.ToString() : addon.LocalInfo.KspVersionMax.ToString()
+                    GuiHelper.UpdateCompatibilityState(OverrideType.version, null, addon.LocalInfo.KspVersionMaxIsNull && addon.LocalInfo.KspVersionMinIsNull ? addon.LocalInfo.KspVersion.ToString() : addon.LocalInfo.KspVersionMax.ToString());
+                }
+            }
+        }
+
+        private void DrawButtonArrowRight(string VersionNumber)
+        {
+            GUIStyle coloredButtonStyle = GuiHelper.CompatibilityState(OverrideType.version, null, VersionNumber) ? buttonStyleGreen : buttonStyle;
+            string buttonLabel = "\u25B6"; //unicode for a triangle, pointing to the right
+            if (GUILayout.Button(buttonLabel, coloredButtonStyle, GUILayout.Width(25), GUILayout.Height(25)))
+            {
+                if (!GuiHelper.CompatibilityState(OverrideType.version, null, VersionNumber))
+                {
+                    GuiHelper.UpdateCompatibilityState(OverrideType.version, null, VersionNumber);
                 }
             }
         }
@@ -519,8 +551,8 @@ namespace KSP_AVC
             this.hasCentred = true;
         }
 
-#endregion
-
+        #endregion
+        
 #region Styles
 
         private void InitialiseStyles()
@@ -611,6 +643,15 @@ namespace KSP_AVC
                     textColor = Color.cyan
                 },
                 alignment = TextAnchor.MiddleLeft,
+            };
+
+            this.labelStyleIgnore = new GUIStyle(HighLogic.Skin.label)
+            {
+                normal =
+                {
+                    textColor = Color.yellow
+                },
+                fontStyle = FontStyle.BoldAndItalic,
             };
         }
 #endregion

--- a/KSP-AVC/Configuration.cs
+++ b/KSP-AVC/Configuration.cs
@@ -105,6 +105,8 @@ namespace KSP_AVC
 
         public static List<string> ToDelete { get; private set; } = new List<string>();
 
+        public static bool ShowDefaultValues { get; set; }
+
         #endregion
 
         #region Methods: public
@@ -295,6 +297,7 @@ namespace KSP_AVC
                 //Some default values so this method can create a config file
                 //modsIgnoreOverride.Add("Kopernicus"); //Unfortunately, the name of Kopernicus is actually "<b><color=#CA7B3C>Kopernicus</color></b>" which may irritates some users
                 OverrideIsDisabledGlobal = true;
+                ShowDefaultValues = true;
                 AvcInterval = 0;
                 //UseKspSkin = true;
                 CfgUpdated = true;
@@ -309,6 +312,7 @@ namespace KSP_AVC
             KSPAVC.AddValue("OVERRIDE_PRIORITY", OverridePriority);
             KSPAVC.AddValue("SIMPLE_PRIORITY", SimplePriority);
             KSPAVC.AddValue("DISABLE_COMPATIBLE_VERSION_OVERRIDE", OverrideIsDisabledGlobal);
+            KSPAVC.AddValue("SHOW_DEFAULT_VALUES", ShowDefaultValues);
 #if STRICT
             KSPAVC.AddValue("STRICT_VERSION", StrictVersion);
 #endif
@@ -408,6 +412,18 @@ namespace KSP_AVC
                         OverrideIsDisabledGlobal = false;
                     else
                         OverrideIsDisabledGlobal = true;
+                    //Logger.Log($"OverrideIsDisabled: {OverrideIsDisabledGlobal}");
+                }
+                catch { }
+            }
+            if (node.HasValue("SHOW_DEFAULT_VALUES"))
+            {
+                try
+                {
+                    if (node.GetValue("SHOW_DEFAULT_VALUES").ToLower() == "false")
+                        ShowDefaultValues = false;
+                    else
+                        ShowDefaultValues = true;
                     //Logger.Log($"OverrideIsDisabled: {OverrideIsDisabledGlobal}");
                 }
                 catch { }

--- a/KSP-AVC/GuiHelper.cs
+++ b/KSP-AVC/GuiHelper.cs
@@ -42,7 +42,7 @@ namespace KSP_AVC
             }
             if (HighLogic.LoadedScene == GameScenes.SPACECENTER)
             {
-                Destroy(this);
+                Destroy(this.gameObject);
             }
         }
 
@@ -69,7 +69,7 @@ namespace KSP_AVC
             }
         }
 
-        public static bool CompatibilityState(OverrideType type, Addon addon)
+        public static bool CompatibilityState(OverrideType type, Addon addon, string oldVersion = "") //requires -1 instead of *
         {
             switch (type)
             {
@@ -80,6 +80,15 @@ namespace KSP_AVC
 
                 case OverrideType.version:
                     {
+                        if (oldVersion != "")
+                        {
+                            oldVersion = oldVersion.Replace("*", "-1");
+                             bool b = (from d in Configuration.CompatibleVersions
+                                       where oldVersion == d.Key
+                                       where d.Value.compatWithVersion.Contains(AddonInfo.ActualKspVersion)
+                                       select d).Any();
+                            return b;
+                        }
                         return addon.IsForcedCompatibleByVersion;
                     }
 
@@ -129,9 +138,6 @@ namespace KSP_AVC
                                 {
                                     Configuration.RemoveOverrideVersion(inputs[0], inputs[i]);
                                 }
-
-
-
                                 return;
                             }
                             int m = inputs.Count();
@@ -166,7 +172,7 @@ namespace KSP_AVC
         
         private static bool validateInput(string userInput)
         {
-            if (!Regex.IsMatch(userInput, @"[^\d\.\-\*\,]")) //matches any character which isn't going to be valid at all
+            if (!Regex.IsMatch(userInput, @"[^\d\.\-\*\,\s]")) //matches any character which isn't going to be valid at all
             {
                 string regexPatternMulti = @"(\d\.\d)\,\s?(\d\.\d)"; //just a rough pattern, should filter out most invalid inputs but definitly not all of them
                 string regexPatternSingle = @"(\d\.\d)"; //checks for at least 2 numbers, sparated by a dot


### PR DESCRIPTION
-Moved default values to addon list
-Added toggle button to hide the default values (Advanced Settings)
-Decent highlighting of addons on the ignore list (bold and italic)
-Fixed: Issue during text input validation
-Fixed: Windows don't close after loading a savegame
-Some internal code changes (CompatibilityState)

I've commented out most of the code which was used to create the toggle buttons (sorry!), so if there are complains about the new system, it will be easy to add back (or add a toggle to switch between both variants). 