### PR TITLE
Create a schema for .version files

### DIFF
--- a/KSP-AVC.schema.json
+++ b/KSP-AVC.schema.json
@@ -107,14 +107,6 @@
         "NAME",
         "VERSION"
     ],
-    "dependencies": {
-        "KSP_VERSION_MAX": [
-            "KSP_VERSION"
-        ],
-        "KSP_VERSION_MIN": [
-            "KSP_VERSION"
-        ]
-    },
     "definitions": {
         "version": {
             "description": "A semantic(?) version",

--- a/KSP-AVC.schema.json
+++ b/KSP-AVC.schema.json
@@ -1,0 +1,153 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Add-on Version Checker file",
+    "description": "A KSP-AVC version file's content",
+    "type": "object",
+    "properties": {
+        "NAME": {
+            "description": "The display name for the add-on",
+            "type": "string"
+        },
+        "URL": {
+            "description": "Location of a remote version file for update checking",
+            "type": "string",
+            "format": "uri"
+        },
+        "DOWNLOAD": {
+            "description": "Web address where the latest version can be downloaded",
+            "type": "string",
+            "format": "uri"
+        },
+        "CHANGE_LOG": {
+            "description": "The complete or incremental change log for the add-on",
+            "type": "string"
+        },
+        "CHANGE_LOG_URL": {
+            "description": "Populates the CHANGE_LOG field using the file at this url",
+            "type": "string",
+            "format": "uri"
+        },
+        "GITHUB": {
+            "description": "Allows KSP-AVC to do release checks with GitHub including setting a download location if one is not specified. If the latest release version is not equal to the version in the file, an update notification will not appear.",
+            "type": "object",
+            "properties": {
+                "USERNAME ": {
+                    "description": "Your GitHub username",
+                    "type": "string"
+                },
+                "REPOSITORY ": {
+                    "description": "The name of the source repository",
+                    "type": "string"
+                },
+                "ALLOW_PRE_RELEASE ": {
+                    "description": "Include pre-releases in the latest release search",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "USERNAME",
+                "REPOSITORY"
+            ]
+        },
+        "KERBAL_STUFF_URL": {
+            "description": "URL to this mod's page on KerbalStuff",
+            "type": "string",
+            "format": "uri"
+        },
+        "VERSION": {
+            "description": "The version of the add-on",
+            "$ref": "#/definitions/version"
+        },
+        "KSP_VERSION": {
+            "description": "Version of KSP that the add-on was made to support",
+            "$ref": "#/definitions/version"
+        },
+        "KSP_VERSION_MIN": {
+            "description": "Minimum version of KSP that the add-on supports",
+            "$ref": "#/definitions/version"
+        },
+        "KSP_VERSION_MAX": {
+            "description": "Maximum version of KSP that the add-on supports",
+            "$ref": "#/definitions/version"
+        },
+        "DISALLOW_VERSION_OVERRIDE": {
+            "type": "boolean",
+            "description": "If true, don't trust KSP-AVC's idea of which game versions are compatible with which other game versions, based on user configuration"
+        },
+        "ASSEMBLY_NAME": {
+            "type": "string",
+            "description": "DO NOT USE, won't work with CKAN; name of a DLL to check for VERSION on the fly"
+        },
+        "KSP_VERSION_INCLUDE": {
+            "description": "DO NOT USE, won't work with CKAN; a list of versions with which this mod is compatible",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/version"
+            },
+            "uniqueItems": true
+        },
+        "KSP_VERSION_EXCLUDE": {
+            "description": "DO NOT USE, won't work with CKAN; a list of versions with which this mod is incompatible",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/version"
+            },
+            "uniqueItems": true
+        },
+        "LOCAL_HAS_PRIORITY": {
+            "type": "boolean",
+            "description": "DO NOT USE, won't work with CKAN; if true, don't override properties using the remote version file"
+        },
+        "REMOTE_HAS_PRIORITY": {
+            "type": "boolean",
+            "description": "DO NOT USE, won't work with CKAN; if false, don't override properties using the remote version file"
+        }
+    },
+    "required": [
+        "NAME",
+        "VERSION"
+    ],
+    "dependencies": {
+        "KSP_VERSION_MAX": [
+            "KSP_VERSION"
+        ],
+        "KSP_VERSION_MIN": [
+            "KSP_VERSION"
+        ]
+    },
+    "definitions": {
+        "version": {
+            "description": "A semantic(?) version",
+            "anyOf" : [
+                {
+                    "type": "string",
+                    "pattern": "^(any|[0-9]+\\.[0-9]+(\\.[0-9]+)?)$"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "MAJOR": {
+                            "description": "Change major version when you make incompatible API changes",
+                            "type": "integer"
+                        },
+                        "MINOR": {
+                            "description": "Change minor version when you add functionality in a backwards-compatible manner",
+                            "type": "integer"
+                        },
+                        "PATCH": {
+                            "description": "Change patch version when you make backwards-compatible bug fixes",
+                            "type": "integer"
+                        },
+                        "BUILD": {
+                            "description": "Build informaion",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "MAJOR"
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Currently the format of .version files has two de facto definitions:

- The old [README] on @cybutek's web site
- The [current KSP-AVC code]

[README]: http://ksp.cybutek.net/kspavc/Documents/README.htm
[current KSP-AVC code]: https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/master/KSP-AVC/AddonInfo.cs

(There are two other versions of the format that are simply out of date and therefore less important, see #25.)

The current KSP-AVC supports properties that aren't listed on the web site, and this can only be discovered by reading the C# code. The lack of a clear standard creates two problems:

- It's difficult to create a .version file correctly, since the full list of available properties and their meanings are not listed anywhere
- Once created, it's difficult to tell whether a .version file is valid

To try to help with these issues, this PR codifies the [current KSP-AVC code] in a JSON schema file, based on work originally done by @janbrohl and mentioned in KSP-CKAN/CKAN#1768. This file can be used to validate .version files and print errors if they aren't valid (potentially helping with #1, functionality not included in this pull request). This can be done with tools like Python's `jsonschema` module or C#'s `NJsonSchema` module. It is also our hope to someday offer it to mod authors via a tool like [Github Action: Validate JSON], potentially warning about errors before modules are even released.

[Github Action: Validate JSON]: https://github.com/marketplace/actions/validate-json

I had to guess on the descriptions of some of the recently added properties, so please feel free to make edits as needed.

**PLEASE** maintain this going forward! It should be updated anytime a new property is added, changed, or removed, ideally in the same pull request.