### PR TITLE
Change update URL to current version on github

### DIFF
--- a/KSP-AVC.version
+++ b/KSP-AVC.version
@@ -1,6 +1,6 @@
 {
   "NAME": "KSP-AVC Plugin",
-  "URL": "http://ksp.spacetux.net/avc/KSP-AVC",
+  "URL": "https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/master/KSP-AVC.version",
   "DOWNLOAD": "https://github.com/linuxgurugamer/KSPAddonVersionChecker/releases",
   "GITHUB": {
     "USERNAME": "linuxgurugamer",


### PR DESCRIPTION
The data on ksp.spacetux.net is out of date.
Even if KSP AVC were working (https://github.com/linuxgurugamer/KSPAddonVersionChecker/issues/27), this out-of-date data would mean AVC wouldn't know about the latest releases.

A similar change should probably be made on all other mods. (Alternatively, update the ksp.spacetux.net data.)