### PR TITLE
Add workflow to validate this repo's .version files

### DIFF
--- a/.github/workflows/AVC-VersionFileValidator.yml
+++ b/.github/workflows/AVC-VersionFileValidator.yml
@@ -1,0 +1,17 @@
+name: Validate AVC .version files
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  validate_version_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Validate files
+        with:
+          exclude: '["TestCases/**/*"]'
+        uses: DasSkelett/AVC-VersionFileValidator@v1


### PR DESCRIPTION
This PR adds a workflow to validate `KSP-AVC.version` and the ones in GameData/.
It uses my GitHub Action found here: https://github.com/DasSkelett/AVC-VersionFileValidator

It triggers for pushes to a branch of this repository and pushes to foreign branches that have an active pull request to this repo, at least if I've read the documentation right.

All the files in TestCases/ are excluded from validation, because I guess they are purposefully wrong for unit testing purposes?
If not and they should be valid... there's a lot of work to do ;)

It can be used as something like a reference implementation I guess.

Let me know what you think!