### PR TITLE
Report which configPath was not found

### DIFF
--- a/MiniAVC/UpdateFrequency.cs
+++ b/MiniAVC/UpdateFrequency.cs
@@ -42,7 +42,7 @@ namespace MiniAVC
         {
             if (!File.Exists(configPath))
             {
-                Logger.Log("Config not found");
+                Logger.Log($"Config not found: {configPath}");
                 return;
             }
 


### PR DESCRIPTION
(Not sure if Unity allows string interpolation.)

This will give more information in the KSP.log file about which file path was not found, aiding the user in debugging.