### PR TITLE
Add null check in MiniAVC for kspExcludeVersions

### DIFF
--- a/MiniAVC/AddonInfo.cs
+++ b/MiniAVC/AddonInfo.cs
@@ -128,6 +128,8 @@ namespace MiniAVC
         {
             get
             {
+                if (this.kspExcludeVersions == null)
+                    return false;
                 bool b = this.kspExcludeVersions.Contains(actualKspVersion);
                 return b;
             }


### PR DESCRIPTION
The NRE check was in the main KSP-AVC/AddonInfo.cs file, but not the MiniAVC/AddonInfo.cs file.