### PR TITLE
Allow multiple versions per file

### DIFF
--- a/MiniAVC/Addon.cs
+++ b/MiniAVC/Addon.cs
@@ -245,10 +245,47 @@ namespace MiniAVC
 #endif
         private void SetRemoteInfo(string json)
         {
-
-            var data = (Dictionary<string, object>)Json.Deserialize(json);
-            RemoteInfo = new AddonInfo(LocalInfo.Url, data);
+            var data = Json.Deserialize(json);
             remoteInfoBase64String = ConvertToBase64(json);
+            
+            if (data is Dictionary<string, object> dataDict)
+            {
+                RemoteInfo = new AddonInfo(LocalInfo.Url, dataDict);
+            }
+            else if (data is List<object> versionDataList)
+            {
+                if (versionDataList.Count == 0)
+                {
+                    throw new FormatException(LocalInfo.Name + ": Remote AVC file contains an empty array");
+                }
+
+                foreach (var versionData in versionDataList)
+                {
+                    var addonInfo = new AddonInfo(LocalInfo.Url, (Dictionary<string, object>)versionData);
+
+                    if (!addonInfo.IsCompatible || addonInfo.Version == null)
+                    {
+                        continue;
+                    }
+
+                    if (RemoteInfo == null || addonInfo.Version > RemoteInfo.Version)
+                    {
+                        RemoteInfo = addonInfo;
+                    }
+                }
+
+                if (RemoteInfo == null)
+                {
+                    Logger.Log(LocalInfo.Name + ": Couldn't find any compatible version in remote info");
+                    SetLocalInfoOnly();
+                    return;
+                }
+            }
+            else
+            {
+                throw new FormatException(LocalInfo.Name + ": Remote AVC file has an unrecognized root element type: " + data?.GetType().ToString() ?? "null");
+            }
+
             RemoteInfo.FetchRemoteData();
 #if true
             if (LocalInfo.Version == RemoteInfo.Version)

--- a/MiniAVC/AddonInfo.cs
+++ b/MiniAVC/AddonInfo.cs
@@ -13,8 +13,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Net;
 //using System.Threading;
 
@@ -40,25 +38,17 @@ namespace MiniAVC
             actualKspVersion = new VersionInfo(Versioning.version_major, Versioning.version_minor, Versioning.Revision);
         }
 
-        public AddonInfo(string path, string json)
+        public AddonInfo(string path, Dictionary<string, object> data)
         {
             try
             {
                 this.path = path;
-                Base64String = Regex.Replace(Convert.ToBase64String(Encoding.ASCII.GetBytes(json)), @"\s+", string.Empty); ;
-                Parse(json);
+                Parse(data);
             }
             catch
             {
-                ParseError = true;
+                Logger.Log("Version file contains errors: " + path);
                 throw;
-            }
-            finally
-            {
-                if (ParseError)
-                {
-                    Logger.Log("Version file contains errors: " + path);
-                }
             }
         }
 
@@ -66,8 +56,6 @@ namespace MiniAVC
         {
             get { return actualKspVersion; }
         }
-
-        public string Base64String { get; private set; } = string.Empty;
 
         public string Download { get; private set; }
 
@@ -148,8 +136,6 @@ namespace MiniAVC
         public bool KspExcludeVersionIsNull { get { return this.kspExcludeVersions == null; } }
 
         public string Name { get; private set; }
-
-        public bool ParseError { get; private set; }
 
         public string Url { get; private set; }
 
@@ -241,14 +227,8 @@ namespace MiniAVC
             return version;
         }
 
-        private void Parse(string json)
+        private void Parse(Dictionary<string, object> data)
         {
-            var data = MiniAVC.Json.Deserialize(json) as Dictionary<string, object>;
-            if (data == null)
-            {
-                ParseError = true;
-                return;
-            }
             foreach (var key in data.Keys)
             {
                 switch (key.ToUpper())

--- a/MiniAVC/MiniAVC.csproj
+++ b/MiniAVC/MiniAVC.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\Output\MiniAVC\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Just in remote file.

Allows AVC to look at a list of versions and determine which is the latest for your KSP Version before notifying the user to update.

Was originally #14, I must have closed that accidentally

CKAN (really NetKAN) equivalent: https://github.com/KSP-CKAN/CKAN/pull/3036